### PR TITLE
Remove at-sign prefixes from model names

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -81,25 +81,7 @@
   }
 
   async function loadCuratedDatabase() {
-    const db = await fetch('data/model-database.json').then(r => r.json());
-    const normalized = normalizeAtSigns(db);
-    return normalized;
-  }
-
-  function normalizeAtSigns(db) {
-    const out = {};
-    for (const [cat, val] of Object.entries(db)) {
-      if (Array.isArray(val)) {
-        out[cat] = val.map(s => s.replace(/^@/, ''));
-      } else if (val && typeof val === 'object') {
-        const sub = {};
-        for (const [k, arr] of Object.entries(val)) {
-          sub[k] = (arr || []).map(s => s.replace(/^@/, ''));
-        }
-        out[cat] = sub;
-      }
-    }
-    return out;
+    return await fetch('data/model-database.json').then(r => r.json());
   }
 
   function buildMergedCategories(curated, flatList) {

--- a/assets/flags.js
+++ b/assets/flags.js
@@ -7,10 +7,15 @@
   class FlagsManager {
     constructor() {
       this.flagsDb = {};
-      this.state = {}; // {'@Model': { flagName: value }}
+      this.state = {}; // {'Model': { flagName: value }}
       try {
         const saved = localStorage.getItem('vgchat_flags_state');
-        if (saved) this.state = JSON.parse(saved);
+        if (saved) {
+          const parsed = JSON.parse(saved);
+          for (const [k, v] of Object.entries(parsed)) {
+            this.state[k.replace(/^@/, '')] = v;
+          }
+        }
       } catch {}
     }
 
@@ -22,9 +27,10 @@
       try { localStorage.setItem('vgchat_flags_state', JSON.stringify(this.state)); } catch {}
     }
 
-    getModelKey(model) {
-      // Flags DB uses '@Model' keys; UI uses plain names.
-      return model.startsWith('@') ? model : `@${model}`;
+    getModelKey(model, { forApi = false } = {}) {
+      // Normalizes model names; add '@' only for API usage
+      const raw = model.replace(/^@/, '');
+      return forApi ? `@${raw}` : raw;
     }
 
     getConfigForModel(model) {

--- a/data/model-database.json
+++ b/data/model-database.json
@@ -1,292 +1,292 @@
 {
   "Favorites": [
-    "@GPT-5",
-    "@GPT-4.1",
-    "@o3-pro",
-    "@o1",
-    "@Gemini-2.5-Pro",
-    "@Claude-Opus-4-Reasoning",
-    "@Claude-Opus-4.1",
-    "@Claude-Opus-4-Search",
-    "@Claude-Sonnet-4-Search",
-    "@Grok-4",
-    "@Mistral-Large-2"
+    "GPT-5",
+    "GPT-4.1",
+    "o3-pro",
+    "o1",
+    "Gemini-2.5-Pro",
+    "Claude-Opus-4-Reasoning",
+    "Claude-Opus-4.1",
+    "Claude-Opus-4-Search",
+    "Claude-Sonnet-4-Search",
+    "Grok-4",
+    "Mistral-Large-2"
   ],
   "Web Search": [
-    "@Claude-Opus-4-Search",
-    "@Claude-Sonnet-4-Search",
-    "@Claude-Sonnet-3.7-Search",
-    "@Gemini-2.5-Flash",
-    "@Gemini-2.5-Pro",
-    "@Grok-4",
-    "@Perplexity-Sonar",
-    "@Perplexity-Sonar-Rsn-Pro",
-    "@GPT-4o-Search",
-    "@Linkup-Deep-Search",
-    "@Linkup-Standard",
-    "@Bagoodex-Web-Search"
+    "Claude-Opus-4-Search",
+    "Claude-Sonnet-4-Search",
+    "Claude-Sonnet-3.7-Search",
+    "Gemini-2.5-Flash",
+    "Gemini-2.5-Pro",
+    "Grok-4",
+    "Perplexity-Sonar",
+    "Perplexity-Sonar-Rsn-Pro",
+    "GPT-4o-Search",
+    "Linkup-Deep-Search",
+    "Linkup-Standard",
+    "Bagoodex-Web-Search"
   ],
   "GPT": {
     "GPT-5 Series": [
-      "@GPT-5-Chat",
-      "@GPT-5",
-      "@GPT-5-mini",
-      "@GPT-5-nano"
+      "GPT-5-Chat",
+      "GPT-5",
+      "GPT-5-mini",
+      "GPT-5-nano"
     ],
     "GPT-4 Series": [
-      "@GPT-4.1",
-      "@GPT-4o-Search",
-      "@GPT-4-Classic",
-      "@GPT-4-Classic-0314",
-      "@GPT-4-Turbo",
-      "@GPT-4.1-mini",
-      "@GPT-4.1-nano",
-      "@GPT-4o",
-      "@GPT-4o-mini",
-      "@GPT-4o-mini-Search",
-      "@GPT-4o-Aug",
-      "@ChatGPT-4o-Latest"
+      "GPT-4.1",
+      "GPT-4o-Search",
+      "GPT-4-Classic",
+      "GPT-4-Classic-0314",
+      "GPT-4-Turbo",
+      "GPT-4.1-mini",
+      "GPT-4.1-nano",
+      "GPT-4o",
+      "GPT-4o-mini",
+      "GPT-4o-mini-Search",
+      "GPT-4o-Aug",
+      "ChatGPT-4o-Latest"
     ],
     "GPT-3.5 Series": [
-      "@GPT-3.5-Turbo",
-      "@GPT-3.5-Turbo-Instruct",
-      "@GPT-3.5-Turbo-Raw"
+      "GPT-3.5-Turbo",
+      "GPT-3.5-Turbo-Instruct",
+      "GPT-3.5-Turbo-Raw"
     ],
     "o-Series": [
-      "@o1",
-      "@o3",
-      "@o3-pro",
-      "@o1-mini",
-      "@o3-mini",
-      "@o3-mini-high",
-      "@o4-mini",
-      "@o3-Pro"
+      "o1",
+      "o3",
+      "o3-pro",
+      "o1-mini",
+      "o3-mini",
+      "o3-mini-high",
+      "o4-mini",
+      "o3-Pro"
     ]
   },
   "GPT - Open Weight": {
     "120B Models": [
-      "@GPT-OSS-120B-T",
-      "@GPT-OSS-120B",
-      "@GPT-OSS-120B-CS",
-      "@OpenAI-GPT-OSS-120B"
+      "GPT-OSS-120B-T",
+      "GPT-OSS-120B",
+      "GPT-OSS-120B-CS",
+      "OpenAI-GPT-OSS-120B"
     ],
     "20B Models": [
-      "@GPT-OSS-20B-T",
-      "@GPT-OSS-20B",
-      "@OpenAI-GPT-OSS-20B"
+      "GPT-OSS-20B-T",
+      "GPT-OSS-20B",
+      "OpenAI-GPT-OSS-20B"
     ]
   },
   "Google": {
     "Gemini 2.5": [
-      "@Gemini-2.5-Pro",
-      "@Gemini-2.5-Flash",
-      "@Gemini-2.5-Flash-Lite",
-      "@Gemini-2.5-Flash-Lite-Preview",
-      "@Gemini-2.5-Flash-Image"
+      "Gemini-2.5-Pro",
+      "Gemini-2.5-Flash",
+      "Gemini-2.5-Flash-Lite",
+      "Gemini-2.5-Flash-Lite-Preview",
+      "Gemini-2.5-Flash-Image"
     ],
     "Gemini 2.0": [
-      "@Gemini-2.0-Flash",
-      "@Gemini-2.0-Flash-Lite",
-      "@Gemini-2.0-Flash-Preview"
+      "Gemini-2.0-Flash",
+      "Gemini-2.0-Flash-Lite",
+      "Gemini-2.0-Flash-Preview"
     ],
     "Gemini 1.5": [
-      "@Gemini-1.5-Pro",
-      "@Gemini-1.5-Pro-Search",
-      "@Gemini-1.5-Flash",
-      "@Gemini-1.5-Flash-Search"
+      "Gemini-1.5-Pro",
+      "Gemini-1.5-Pro-Search",
+      "Gemini-1.5-Flash",
+      "Gemini-1.5-Flash-Search"
     ],
     "Gemma": [
-      "@Gemma-3-27B",
-      "@Gemma-2-27b-T"
+      "Gemma-3-27B",
+      "Gemma-2-27b-T"
     ]
   },
   "Claude": {
     "Opus": [
-      "@Claude-Opus-4.1",
-      "@Claude-Opus-4",
-      "@Claude-Opus-4-Reasoning",
-      "@Claude-Opus-4-Search",
-      "@Claude-Opus-3"
+      "Claude-Opus-4.1",
+      "Claude-Opus-4",
+      "Claude-Opus-4-Reasoning",
+      "Claude-Opus-4-Search",
+      "Claude-Opus-3"
     ],
     "Sonnet": [
-      "@Claude-Sonnet-4",
-      "@Claude-Sonnet-4-Reasoning",
-      "@Claude-Sonnet-4-Search",
-      "@Claude-Sonnet-3.5",
-      "@Claude-Sonnet-3.5-June",
-      "@Claude-Sonnet-3.5-Search",
-      "@Claude-Sonnet-3.7",
-      "@Claude-Sonnet-3.7-Reasoning",
-      "@Claude-Sonnet-3.7-Search"
+      "Claude-Sonnet-4",
+      "Claude-Sonnet-4-Reasoning",
+      "Claude-Sonnet-4-Search",
+      "Claude-Sonnet-3.5",
+      "Claude-Sonnet-3.5-June",
+      "Claude-Sonnet-3.5-Search",
+      "Claude-Sonnet-3.7",
+      "Claude-Sonnet-3.7-Reasoning",
+      "Claude-Sonnet-3.7-Search"
     ],
     "Haiku": [
-      "@Claude-Haiku-3.5",
-      "@Claude-Haiku-3",
-      "@Claude-Haiku-3.5-Search"
+      "Claude-Haiku-3.5",
+      "Claude-Haiku-3",
+      "Claude-Haiku-3.5-Search"
     ]
   },
   "Grok": [
-    "@Grok-4",
-    "@Grok-3",
-    "@Grok-3-Mini",
-    "@Grok-Code-Fast-1",
-    "@Grok-2"
+    "Grok-4",
+    "Grok-3",
+    "Grok-3-Mini",
+    "Grok-Code-Fast-1",
+    "Grok-2"
   ],
   "Llama 4": [
-    "@Llama-4-Scout-B10",
-    "@Llama-4-Maverick",
-    "@Llama-4-Scout-T",
-    "@Llama-4-Scout-CS",
-    "@Llama-4-Scout",
-    "@Llama-4-Maverick-T",
-    "@Llama-4-Maverick-B10"
+    "Llama-4-Scout-B10",
+    "Llama-4-Maverick",
+    "Llama-4-Scout-T",
+    "Llama-4-Scout-CS",
+    "Llama-4-Scout",
+    "Llama-4-Maverick-T",
+    "Llama-4-Maverick-B10"
   ],
   "Llama 3.X": {
     "405B Models": [
-      "@Llama-3.1-405B",
-      "@Llama-3.1-405B-T",
-      "@Llama-3.1-405B-FW",
-      "@Llama-3.1-405B-FP16"
+      "Llama-3.1-405B",
+      "Llama-3.1-405B-T",
+      "Llama-3.1-405B-FW",
+      "Llama-3.1-405B-FP16"
     ],
     "70B Models": [
-      "@Llama-3-70b-Groq",
-      "@Llama-3.3-70B",
-      "@Llama-3.1-Nemotron",
-      "@Llama-3.3-70B-DI",
-      "@Llama-3.3-70B-CS",
-      "@Llama-3.3-70B-Vers",
-      "@Llama-3-70B-FP16",
-      "@Llama-3-70B-T",
-      "@Llama-3.1-70B",
-      "@Llama-3.1-70B-FP16",
-      "@Llama-3.1-70B-FW",
-      "@Llama-3.1-70B-T",
-      "@Llama-3.3-70B-FW",
-      "@Llama-3.3-70B-N"
+      "Llama-3-70b-Groq",
+      "Llama-3.3-70B",
+      "Llama-3.1-Nemotron",
+      "Llama-3.3-70B-DI",
+      "Llama-3.3-70B-CS",
+      "Llama-3.3-70B-Vers",
+      "Llama-3-70B-FP16",
+      "Llama-3-70B-T",
+      "Llama-3.1-70B",
+      "Llama-3.1-70B-FP16",
+      "Llama-3.1-70B-FW",
+      "Llama-3.1-70B-T",
+      "Llama-3.3-70B-FW",
+      "Llama-3.3-70B-N"
     ],
     "8B Models": [
-      "@Llama-3-8B-T",
-      "@Llama-3-8b-Groq",
-      "@Llama-3.1-8B",
-      "@Llama-3.1-8B-CS",
-      "@Llama-3.1-8B-DI",
-      "@Llama-3.1-8B-FP16",
-      "@Llama-3.1-8B-FW",
-      "@Llama-3.1-8B-T-128k"
+      "Llama-3-8B-T",
+      "Llama-3-8b-Groq",
+      "Llama-3.1-8B",
+      "Llama-3.1-8B-CS",
+      "Llama-3.1-8B-DI",
+      "Llama-3.1-8B-FP16",
+      "Llama-3.1-8B-FW",
+      "Llama-3.1-8B-T-128k"
     ]
   },
   "Qwen": {
     "480B": [
-      "@Qwen3-480B-Coder-CS",
-      "@Qwen3-Coder-480B-T",
-      "@Qwen3-Coder-480B-N"
+      "Qwen3-480B-Coder-CS",
+      "Qwen3-Coder-480B-T",
+      "Qwen3-Coder-480B-N"
     ],
     "235B": [
-      "@Qwen-3-235B-2507-T",
-      "@Qwen3-235B-2507-FW",
-      "@Qwen3-235B-2507-CS",
-      "@Qwen3-235B-A22B",
-      "@Qwen3-235B-A22B-DI",
-      "@Qwen3-235B-A22B-N",
-      "@Qwen3-235B-Think-CS"
+      "Qwen-3-235B-2507-T",
+      "Qwen3-235B-2507-FW",
+      "Qwen3-235B-2507-CS",
+      "Qwen3-235B-A22B",
+      "Qwen3-235B-A22B-DI",
+      "Qwen3-235B-A22B-N",
+      "Qwen3-235B-Think-CS"
     ],
     "72B": [
-      "@Qwen-72B-T",
-      "@Qwen2-72B-Instruct-T",
-      "@Qwen2.5-VL-72B-T",
-      "@Qwen-2.5-72B-T"
+      "Qwen-72B-T",
+      "Qwen2-72B-Instruct-T",
+      "Qwen2.5-VL-72B-T",
+      "Qwen-2.5-72B-T"
     ],
     "32B": [
-      "@Qwen3-30B-A3B-Instruct",
-      "@Qwen2.5-Coder-32B",
-      "@Qwen2.5-Coder-32B-T",
-      "@Qwen3-32B-CS",
-      "@Qwen3-Coder-30B-A3B"
+      "Qwen3-30B-A3B-Instruct",
+      "Qwen2.5-Coder-32B",
+      "Qwen2.5-Coder-32B-T",
+      "Qwen3-32B-CS",
+      "Qwen3-Coder-30B-A3B"
     ],
     "Others": [
-      "@Qwen-2.5-7B-T",
-      "@Qwen-2.5-VL-32b",
-      "@Qwen3-Coder"
+      "Qwen-2.5-7B-T",
+      "Qwen-2.5-VL-32b",
+      "Qwen3-Coder"
     ]
   },
   "DeepSeek": {
     "R1 Series": [
-      "@DeepSeek-R1",
-      "@DeepSeek-R1-FW",
-      "@DeepSeek-R1-DI",
-      "@DeepSeek-R1-N",
-      "@DeepSeek-R1-Distill",
-      "@DeepSeek-R1-Turbo-DI"
+      "DeepSeek-R1",
+      "DeepSeek-R1-FW",
+      "DeepSeek-R1-DI",
+      "DeepSeek-R1-N",
+      "DeepSeek-R1-Distill",
+      "DeepSeek-R1-Turbo-DI"
     ],
     "V3 Series": [
-      "@DeepSeek-V3.1",
-      "@DeepSeek-V3.1-Chat",
-      "@DeepSeek-V3.1-N",
-      "@Deepseek-V3-FW",
-      "@DeepSeek-V3",
-      "@DeepSeek-V3-DI",
-      "@DeepSeek-V3-Turbo-DI"
+      "DeepSeek-V3.1",
+      "DeepSeek-V3.1-Chat",
+      "DeepSeek-V3.1-N",
+      "Deepseek-V3-FW",
+      "DeepSeek-V3",
+      "DeepSeek-V3-DI",
+      "DeepSeek-V3-Turbo-DI"
     ],
     "Specialized": [
-      "@DeepSeek-Prover-V2",
-      "@DeepClaude"
+      "DeepSeek-Prover-V2",
+      "DeepClaude"
     ]
   },
   "Mistral": {
     "Large": [
-      "@Mistral-Large-2"
+      "Mistral-Large-2"
     ],
     "Medium": [
-      "@Mistral-Medium-3",
-      "@Mistral-Medium",
-      "@Magistral-Medium-2506-Thinking"
+      "Mistral-Medium-3",
+      "Mistral-Medium",
+      "Magistral-Medium-2506-Thinking"
     ],
     "Small": [
-      "@Mistral-Small-3.2",
-      "@Mistral-Small-3.1",
-      "@Mistral-Small-3",
-      "@Mistral-7B-v0.3-DI",
-      "@Mistral-7B-v0.3-T"
+      "Mistral-Small-3.2",
+      "Mistral-Small-3.1",
+      "Mistral-Small-3",
+      "Mistral-7B-v0.3-DI",
+      "Mistral-7B-v0.3-T"
     ],
     "Specialized": [
-      "@Mistral-NeMo",
-      "@Mixtral8x22b-Inst-FW"
+      "Mistral-NeMo",
+      "Mixtral8x22b-Inst-FW"
     ]
   },
   "Perplexity": [
-    "@Perplexity-R1-1776",
-    "@Perplexity-Sonar",
-    "@Perplexity-Sonar-Pro",
-    "@Perplexity-Sonar-Rsn",
-    "@Perplexity-Sonar-Rsn-Pro"
+    "Perplexity-R1-1776",
+    "Perplexity-Sonar",
+    "Perplexity-Sonar-Pro",
+    "Perplexity-Sonar-Rsn",
+    "Perplexity-Sonar-Rsn-Pro"
   ],
   "Others": [
-    "@Aya-Expanse-32B",
-    "@Aya-Vision",
-    "@Command-R",
-    "@Command-R-Plus",
-    "@GLM-4.5",
-    "@GLM-4.5-Air",
-    "@GLM-4.5-Air-T",
-    "@GLM-4.5-FW",
-    "@GLM-4.5-Versatile",
-    "@GPT-Researcher",
-    "@Inception-Mercury",
-    "@Inception-Mercury-Coder",
-    "@Hermes-3-70B",
-    "@Kimi-K2",
-    "@Kimi-K2-0905-T",
-    "@Kimi-K2-Instruct",
-    "@Kimi-K2-T",
-    "@MiniMax-M1",
-    "@Phi-4-DI",
-    "@QwQ-32B-B10",
-    "@QwQ-32B-Preview-T",
-    "@QwQ-32B-T",
-    "@Reka-Core",
-    "@Reka-Flash",
-    "@Reka-Research",
-    "@Tako",
-    "@Solar-Pro-2"
+    "Aya-Expanse-32B",
+    "Aya-Vision",
+    "Command-R",
+    "Command-R-Plus",
+    "GLM-4.5",
+    "GLM-4.5-Air",
+    "GLM-4.5-Air-T",
+    "GLM-4.5-FW",
+    "GLM-4.5-Versatile",
+    "GPT-Researcher",
+    "Inception-Mercury",
+    "Inception-Mercury-Coder",
+    "Hermes-3-70B",
+    "Kimi-K2",
+    "Kimi-K2-0905-T",
+    "Kimi-K2-Instruct",
+    "Kimi-K2-T",
+    "MiniMax-M1",
+    "Phi-4-DI",
+    "QwQ-32B-B10",
+    "QwQ-32B-Preview-T",
+    "QwQ-32B-T",
+    "Reka-Core",
+    "Reka-Flash",
+    "Reka-Research",
+    "Tako",
+    "Solar-Pro-2"
   ]
 }

--- a/data/model-flags.json
+++ b/data/model-flags.json
@@ -1,5 +1,5 @@
 {
-  "@Claude-Opus-4": {
+  "Claude-Opus-4": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -7,7 +7,7 @@
       "default": "default"
     }
   },
-  "@Claude-Opus-4-Reasoning": {
+  "Claude-Opus-4-Reasoning": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -15,7 +15,7 @@
       "default": "default"
     }
   },
-  "@Claude-Opus-4-Search": {
+  "Claude-Opus-4-Search": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -23,7 +23,7 @@
       "default": "default"
     }
   },
-  "@Claude-Opus-4.1": {
+  "Claude-Opus-4.1": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -31,7 +31,7 @@
       "default": "default"
     }
   },
-  "@Claude-Sonnet-3.7": {
+  "Claude-Sonnet-3.7": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -39,7 +39,7 @@
       "default": "default"
     }
   },
-  "@Claude-Sonnet-3.7-Reasoning": {
+  "Claude-Sonnet-3.7-Reasoning": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -47,7 +47,7 @@
       "default": "default"
     }
   },
-  "@Claude-Sonnet-3.7-Search": {
+  "Claude-Sonnet-3.7-Search": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -55,7 +55,7 @@
       "default": "default"
     }
   },
-  "@Claude-Sonnet-4": {
+  "Claude-Sonnet-4": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -63,7 +63,7 @@
       "default": "default"
     }
   },
-  "@Claude-Sonnet-4-Reasoning": {
+  "Claude-Sonnet-4-Reasoning": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -71,7 +71,7 @@
       "default": "default"
     }
   },
-  "@Claude-Sonnet-4-Search": {
+  "Claude-Sonnet-4-Search": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -79,7 +79,7 @@
       "default": "default"
     }
   },
-  "@Gemini-2.5-Flash": {
+  "Gemini-2.5-Flash": {
     "thinking_budget": {
       "type": "stepped",
       "steps": [
@@ -94,7 +94,7 @@
       "default": "default"
     }
   },
-  "@Gemini-2.5-Flash-Lite": {
+  "Gemini-2.5-Flash-Lite": {
     "thinking_budget": {
       "type": "stepped",
       "steps": [
@@ -109,7 +109,7 @@
       "default": "default"
     }
   },
-  "@Gemini-2.5-Pro": {
+  "Gemini-2.5-Pro": {
     "thinking_budget": {
       "type": "stepped",
       "steps": [
@@ -126,7 +126,7 @@
       "default": "default"
     }
   },
-  "@GPT-5": {
+  "GPT-5": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -138,7 +138,7 @@
       "default": "default"
     }
   },
-  "@GPT-5-mini": {
+  "GPT-5-mini": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -150,7 +150,7 @@
       "default": "default"
     }
   },
-  "@GPT-5-nano": {
+  "GPT-5-nano": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -162,7 +162,7 @@
       "default": "default"
     }
   },
-  "@o1": {
+  "o1": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -173,7 +173,7 @@
       "default": "default"
     }
   },
-  "@o3": {
+  "o3": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -184,7 +184,7 @@
       "default": "default"
     }
   },
-  "@o3-mini": {
+  "o3-mini": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -195,7 +195,7 @@
       "default": "default"
     }
   },
-  "@o3-pro": {
+  "o3-pro": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -206,7 +206,7 @@
       "default": "default"
     }
   },
-  "@o4-mini": {
+  "o4-mini": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -217,7 +217,7 @@
       "default": "default"
     }
   },
-  "@Grok-3-Mini": {
+  "Grok-3-Mini": {
     "reasoning_effort": {
       "type": "stepped",
       "steps": [
@@ -227,7 +227,7 @@
       "default": "default"
     }
   },
-  "@Tako": {
+  "Tako": {
     "specificity": {
       "type": "slider",
       "min": 0,
@@ -235,7 +235,7 @@
       "default": "default"
     }
   },
-  "@Linkup-Deep-Search": {
+  "Linkup-Deep-Search": {
     "advanced_settings": {
       "type": "advanced",
       "fields": {
@@ -283,7 +283,7 @@
       }
     }
   },
-  "@Linkup-Standard": {
+  "Linkup-Standard": {
     "thinking_budget": {
       "type": "slider",
       "min": 0,
@@ -337,7 +337,7 @@
       }
     }
   },
-  "@Bagoodex-Web-Search": {
+  "Bagoodex-Web-Search": {
     "advanced_settings": {
       "type": "advanced",
       "fields": {


### PR DESCRIPTION
## Summary
- store model and flag names without leading `@`
- simplify curated model loading and drop `normalizeAtSigns`
- update FlagsManager to handle raw names and add `@` only for API use

## Testing
- `node - <<'NODE' ... hasModel ... NODE`
- `node - <<'NODE' ... FlagsManager ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_68bfd1a451948332a943eed50096217f